### PR TITLE
Update readme to use new command from fisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ $ env | grep BAZ
 ## [fisherman](https://github.com/fisherman/fisherman) (recommended)
 
 ```
-fisher add joehillen/ev-fish
+fisher install joehillen/ev-fish
 ```
 
 ## Using [fundle](https://github.com/tuvistavie/fundle)


### PR DESCRIPTION
The command `fisher add joehillen/ev-fish` no longer works, it should be `fisher instsall joehillen/ev-fish`